### PR TITLE
hf read route

### DIFF
--- a/src/routes/read.router.ts
+++ b/src/routes/read.router.ts
@@ -6,7 +6,7 @@ import eventQuery from "../middlewares/event-query";
 import {Op} from "sequelize";
 import {MIDNIGHT_ACTIONS, MINUTE_ACTIONS, NETWORK_EVENTS, REGISTRY_EVENTS} from "../modules/chain-events";
 import {findOnABI} from "../utils/find-on-abi";
-import { ApiBlockSniffer } from "src/services/api-block-sniffer";
+import {ApiBlockSniffer} from "src/services/api-block-sniffer";
 
 const router = Router();
 
@@ -59,7 +59,7 @@ router.get(`/:chainId/:address/:event`, async (req, res) => {
         res.status(200).json([data]).end();
       });
   else
-    (new ApiBlockSniffer(chainIdExists.chainRpc, {[address]: {abi, events}}, from, to))
+    (new ApiBlockSniffer(chainIdExists.chainRpc, {[address]: {abi, events}}, from))
       .onParsed()
       .then(data => {
         res.status(200).json(data).end();

--- a/src/services/api-block-sniffer.ts
+++ b/src/services/api-block-sniffer.ts
@@ -4,9 +4,8 @@ import {BlockSniffer} from "src/services/block-sniffer";
 export class ApiBlockSniffer extends BlockSniffer {
   constructor(readonly web3Host: string,
               readonly mappedEventActions: MappedEventActions,
-              readonly startBlock: number = 0,
-              readonly targetBlock = 0) {
-    super(web3Host, mappedEventActions, startBlock, targetBlock, null, 0);
+              readonly startBlock: number = 0) {
+    super(web3Host, mappedEventActions, startBlock, startBlock + 1, null, 0);
   }
 
   // remove these because they are not needed on this ephemeral state

--- a/src/services/api-block-sniffer.ts
+++ b/src/services/api-block-sniffer.ts
@@ -1,13 +1,18 @@
-import { MappedEventActions } from "src/interfaces/block-sniffer";
-import { BlockSniffer } from "src/services/block-sniffer";
+import {MappedEventActions} from "src/interfaces/block-sniffer";
+import {BlockSniffer} from "src/services/block-sniffer";
 
 export class ApiBlockSniffer extends BlockSniffer {
   constructor(readonly web3Host: string,
               readonly mappedEventActions: MappedEventActions,
               readonly startBlock: number = 0,
               readonly targetBlock = 0) {
-    super(web3Host, mappedEventActions, startBlock, targetBlock);
+    super(web3Host, mappedEventActions, startBlock, targetBlock, null, 0);
   }
 
-  protected async saveCurrentBlock(currentBlock = 0) {}
+  // remove these because they are not needed on this ephemeral state
+  protected async saveCurrentBlock(currentBlock = 0) {
+  }
+
+  protected async prepareCurrentBlock() {
+  }
 }

--- a/src/services/block-sniffer.ts
+++ b/src/services/block-sniffer.ts
@@ -102,10 +102,6 @@ export class BlockSniffer {
    * the mappedEventActions[contractAddress].events it will call its action function
    */
   async start(immediately = false) {
-    loggerHandler.info(`BlockSniffer (chain:${this.#actingChainId}) ${this.#interval ? 're' : ''}starting`);
-    loggerHandler.debug(`polling every ${this.interval / 1000}s (immediately: ${immediately.toString()}`);
-    loggerHandler.debug(``)
-
     const callback = () =>
       this.#fetchingLogs
         ? () => null
@@ -116,8 +112,12 @@ export class BlockSniffer {
           });
 
     this.clearInterval();
-
     this.#actingChainId = await this.#connection.eth.getChainId();
+
+    loggerHandler.info(`BlockSniffer (chain:${this.#actingChainId}) ${this.#interval ? 're' : ''}starting`);
+    loggerHandler.debug(`${this.interval ? `polling every ${this.interval / 1000}s` : ``} (immediately: ${immediately.toString()}`);
+    loggerHandler.debug(``)
+
     if (!this.#currentBlock)
       await this.prepareCurrentBlock();
 

--- a/src/services/block-sniffer.ts
+++ b/src/services/block-sniffer.ts
@@ -115,7 +115,7 @@ export class BlockSniffer {
     this.#actingChainId = await this.#connection.eth.getChainId();
 
     loggerHandler.info(`BlockSniffer (chain:${this.#actingChainId}) ${this.#interval ? 're' : ''}starting`);
-    loggerHandler.debug(`${this.interval ? `polling every ${this.interval / 1000}s` : ``} (immediately: ${immediately.toString()}`);
+    loggerHandler.debug(`${this.interval ? `polling every ${this.interval / 1000}s, ` : ``}immediately: ${immediately.toString()}`);
     loggerHandler.debug(``)
 
     if (!this.#currentBlock)


### PR DESCRIPTION
change logger to act only after having a chainId loaded onto the prop, make it so api-block-sniffer.ts cant prepareCurrentBlock